### PR TITLE
message: support new date-time format

### DIFF
--- a/broker/message/timestamp.go
+++ b/broker/message/timestamp.go
@@ -31,6 +31,13 @@ func (t Timestamp) MarshalJSON() ([]byte, error) {
 	return []byte(str), nil
 }
 
+var timeOtherFormats = []string{
+	// Format described in the spec that time.RFC3339 does not cover.
+	"2006-01-02T15:04Z07:00",
+	// Format seen in the wild: "2019-10-31T16:20:05.921+0000".
+	"2006-01-02T15:04:05.999-0700",
+}
+
 // UnmarshalJSON implements the json.Unmarshaler interface.
 // The time is expected to be a quoted string in RFC 3339 format.
 func (t *Timestamp) UnmarshalJSON(data []byte) error {
@@ -49,12 +56,13 @@ func (t *Timestamp) UnmarshalJSON(data []byte) error {
 		*t = Timestamp(ts)
 		return nil
 	}
-	// Like time.RFC3339 without the second component which is accepted by RDSS.
-	const RFC3339woSec = "2006-01-02T15:04Z07:00"
-	ts, err = time.Parse(`"`+RFC3339woSec+`"`, str)
-	if err == nil {
-		*t = Timestamp(ts)
-		return nil
+	// Other formats.
+	for _, format := range timeOtherFormats {
+		ts, err = time.Parse(`"`+format+`"`, str)
+		if err == nil {
+			*t = Timestamp(ts)
+			return nil
+		}
 	}
 	return err
 }

--- a/broker/message/timestamp_test.go
+++ b/broker/message/timestamp_test.go
@@ -58,6 +58,7 @@ func TestTimestampDecoding(t *testing.T) {
 		expected time.Time
 		wantErr  bool
 	}{
+		// Seen in the spec.
 		{
 			[]byte(`{"prop": "1997-07-16T19:20+01:00"}`),
 			"YYYY-MM-DDThh:mmTZD",
@@ -76,6 +77,20 @@ func TestTimestampDecoding(t *testing.T) {
 			time.Date(1997, time.July, 16, 19, 20, 30, 450000000, time.FixedZone("+0100", 3600)),
 			false,
 		},
+		// Seen in production.
+		{
+			[]byte(`{"prop": "2019-10-31T16:20:05.921+0000"}`),
+			"Accepted",
+			time.Date(2019, time.October, 31, 16, 20, 5, 921000000, time.UTC),
+			false,
+		},
+		{
+			[]byte(`{"prop": "2019-10-31T16:20:05.921+0100"}`),
+			"Accepted",
+			time.Date(2019, time.October, 31, 16, 20, 5, 921000000, time.FixedZone("+0100", 3600)),
+			false,
+		},
+		// Unexpected.
 		{
 			[]byte(`{"prop": null}`),
 			"Zero value",


### PR DESCRIPTION
@howard-jisc, here's a small change to accommodate the `2019-10-31T16:20:05.921+0000` format seen in your latest message.